### PR TITLE
This may not be the best place to require pathname, but it works

### DIFF
--- a/lib/utopia/content/node.rb
+++ b/lib/utopia/content/node.rb
@@ -22,6 +22,8 @@ require_relative 'processor'
 require_relative 'links'
 require_relative 'transaction'
 
+require 'pathname'
+
 module Utopia
 	class Content
 		class Node


### PR DESCRIPTION
The pathname module needs to be required since it's not in ruby-core.