### PR TITLE
Rainbow 2.2.x does not build in deployment mode.

### DIFF
--- a/utopia.gemspec
+++ b/utopia.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency 'mime-types', '~> 3.0'
 	
 	spec.add_dependency 'samovar', '~> 1.2'
-	spec.add_dependency 'rainbow', '~> 2.0'
+	spec.add_dependency 'rainbow', '~> 2.1.0'
 	
 	spec.add_dependency 'rack', '~> 2.0'
 	


### PR DESCRIPTION
When rainbow is installed with the `--deploy` flag on bundler it attempts building native modules which fails. [This issue](https://github.com/sickill/rainbow/issues/44) seems to have been known for quite a while.