### PR TITLE
Add rubocop task on Rakefile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,6 @@ group :test do
 	
 	gem 'simplecov'
 	gem 'coveralls', require: false
+
+  gem 'rubocop', '~> 0.49.1'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,13 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:test)
 
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.patterns = ['{benchmarks,documentation,lib,setup,spec}/**/*.rb'] +
+               %w[Gemfile Rakefile utopia.gemspec]
+  t.options = %w[--display-cop-names --extra-details --display-style-guide]
+end
+
 task :documentation do
 	sh('yard', '-o', "documentation/public/code")
 	


### PR DESCRIPTION
Hello :)

I am seeing that your `utopia` module often has tab indent and tailing spaces.
The tab indent may be coming from your C language background.
However in the Ruby world, I think 2 spaces indent is very standard.
Though maybe you can select the indent type with the config file `.rubocop.yml`, if you like tab indent.
Anyway, Rubocop helps you to implement Ruby code. :)

I will show you use case with Rubocop.

In my experience, Rubocop change the rule after bumping minior version, it would be better to pin the version.

```
$ bundle install --path vendor/bundle

$ bundle list | grep rubocop
  * rubocop (0.49.1)

$ bundle exec rake -T
rake build                 # Build utopia-2.1.0.gem into the pkg directory
rake clean                 # Remove any temporary products
rake clobber               # Remove any generated files
rake install               # Build and install utopia-2.1.0.gem into system gems
rake install:local         # Build and install utopia-2.1.0.gem into system gems without ...
rake release[remote]       # Create tag v2.1.0 and build and push utopia-2.1.0.gem to Rub...
rake rubocop               # Run RuboCop
rake rubocop:auto_correct  # Auto-correct RuboCop offenses
rake test                  # Run RSpec code examples

$ bundle exec rake rubocop >& rubocop.log

$ view rubocop.log
```

Ideally after we fix the Rubocop violations, the `rake rubocop` task can be executed in pull-request and `bundle exec rake` default task.

