### PR TITLE
Session validation to check for session expiry.

### DIFF
--- a/spec/utopia/session_spec.rb
+++ b/spec/utopia/session_spec.rb
@@ -102,6 +102,15 @@ module Utopia::SessionSpec
 			get "/session-get?key=foo"
 			expect(last_response.body).to be == ""
 		end
+
+		it "should fail if expired cookie is sent with the request" do
+			session_cookie = last_response['Set-Cookie'].split(';')[0]
+			sleep 6 # sleep longer than the session timeout
+			header 'Cookie', session_cookie
+
+			get "/session-get?key=foo"
+			expect(last_response.body).to be == ""
+		end
 		
 		it "shouldn't fail if ip address is changed" do
 			# Change user agent:

--- a/spec/utopia/session_spec.ru
+++ b/spec/utopia/session_spec.ru
@@ -1,7 +1,7 @@
 
 use Utopia::Session,
 	secret: "97111cabf4c1a5e85b8029cf7c61aa44424fc24a",
-	expires_after: 3600 * 48,
+	expires_after: 5,
 	update_timeout: 1
 
 run lambda { |env|


### PR DESCRIPTION
Previously `Utopia::Session` relied only on the client's user agent honoring the `Expires=` directive in the `Set-Cookie` header. This could mean that an expired session cookie can possibly still be treated by the backend as valid which could be a minor security issue.

This PR fixes that by adding an extra validation check to `Utopia::Session.validate_session!`, an expired session is just as invalid as a session with the wrong UA string.